### PR TITLE
Add dec nil assertion for non-numeric value

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -235,9 +235,10 @@ function testIncDec ()
 	newValue = client:dec(key, incValue)
 	assert(newValue == initial + incValue - incValue)
 
-	-- Incompatable types
-	client:set(key, "not-a-number")
-	assert(client:inc(key, incValue) == nil)
+        -- Incompatible types
+        client:set(key, "not-a-number")
+        assert(client:inc(key, incValue) == nil)
+        assert(client:dec(key, incValue) == nil)
 
 	client:close()
 end


### PR DESCRIPTION
## Summary
- check that `client:dec` also returns `nil` when the key holds a non‑numeric value
- fix typo in incompatible types comment

## Testing
- `make test` *(fails: `/usr/bin/lua5.4: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_6887aa2abf6c832a84c4cef16345ee8f